### PR TITLE
fix(api): reduce partner token cache TTL from 23h to 1h

### DIFF
--- a/src/shared/api.js
+++ b/src/shared/api.js
@@ -77,7 +77,7 @@ export const getPartnerToken = async () => {
     }),
     headers: DEFAULT_HEADERS,
     next: {
-      revalidate: 60 * 60 * 23,
+      revalidate: 60 * 60,
       tags: ["partnertoken"],
     },
   });


### PR DESCRIPTION
## Problem

`getPartnerToken()` cached the partner token for 23 hours. When the backend invalidates the token before cache expiry, all subsequent API requests (`getRooms`, `getRoom`, `getIframe`) send a stale token and receive **403 Forbidden** — intermittently, depending on when backend token rotation happens.

## Fix

Reduce `revalidate` from `60 * 60 * 23` (23h) to `60 * 60` (1h) in `src/shared/api.js`.

## Changes

- `src/shared/api.js` — partner token cache TTL: 23h → 1h